### PR TITLE
Fix The Guardian

### DIFF
--- a/products/the-guardian.toml
+++ b/products/the-guardian.toml
@@ -1,7 +1,7 @@
 name = "The Guardian"
 description = "The Guardian is a leading British news organization with worldwide coverage."
 slug = "the-guardian"
-hostnames = [ "theguardian.com" ]
+hostnames = [ "theguardian.com", "theguardian.co.uk" ]
 sources = [ "https://www.theguardian.com/help/privacy-policy" ]
 contributors = [ "vutut" ]
 

--- a/products/the-guardian.toml
+++ b/products/the-guardian.toml
@@ -1,7 +1,7 @@
 name = "The Guardian"
 description = "The Guardian is a leading British news organization with worldwide coverage."
 slug = "the-guardian"
-hostnames = [ "theguardian.co.uk" ]
+hostnames = [ "theguardian.com" ]
 sources = [ "https://www.theguardian.com/help/privacy-policy" ]
 contributors = [ "vutut" ]
 


### PR DESCRIPTION
**Type of pull request:** product edit

**Related issues:** n/a

---

This PR fixes the The Guardian assessment as it incorrectly used a local domain instead of the general global one.